### PR TITLE
Update database schema and automate static data import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,4 @@ node_modules/
 .copilot/
 .github/
 exam_tool_swimlane.drawio
+localfiles/

--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,4 @@ __marimo__/
 node_modules/
 .copilot/
 .github/
+exam_tool_swimlane.drawio

--- a/Source/backend/README.md
+++ b/Source/backend/README.md
@@ -19,6 +19,25 @@ docker compose up -d
 
 Configuratie voor API (`APP_NAME`, `APP_VERSION`, `API_PREFIX`, `CORS_ALLOWED_ORIGINS`) en database (`PG*`) wordt automatisch uit `.env` geladen.
 
+`init_postgres.sh` importeert daarna automatisch statische referentiedata uit `localfiles/output`:
+
+- studenten: `students_import_normalized_v2.csv`
+- reguliere producten: `products_regular_import_normalized.csv`
+- verrassingsopdrachten: `products_surprise_import_normalized_v2.csv`
+- beoordelaars: `assessors_import_normalized_v2.csv`
+
+Import overslaan:
+
+```bash
+IMPORT_STATIC_DATA=false ./scripts/init_postgres.sh
+```
+
+Alleen statische data opnieuw importeren:
+
+```bash
+./scripts/import_static_data.sh
+```
+
 ## Backend starten
 
 ```bash

--- a/Source/backend/db/migrations/002_create_core_exam_tables.sql
+++ b/Source/backend/db/migrations/002_create_core_exam_tables.sql
@@ -5,40 +5,19 @@ CREATE TABLE IF NOT EXISTS students (
     program_code VARCHAR(50) NOT NULL,
     phase VARCHAR(100) NOT NULL,
     email VARCHAR(255),
-    assignment_advanced TEXT,
-    assignment_competent TEXT,
-    assignment_herkansing TEXT,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS exams (
-    id BIGSERIAL PRIMARY KEY,
-    exam_date DATE NOT NULL,
-    exam_type VARCHAR(100) NOT NULL,
-    room VARCHAR(100) NOT NULL,
-    exam_time TIME NOT NULL,
-    flag_oproepbrief BOOLEAN NOT NULL DEFAULT FALSE,
-    flag_verrassing BOOLEAN NOT NULL DEFAULT FALSE,
-    flag_wakker BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS exam_students (
     id BIGSERIAL PRIMARY KEY,
-    exam_id BIGINT NOT NULL REFERENCES exams(id) ON DELETE CASCADE,
+    exam_planning_id BIGINT NOT NULL REFERENCES exam_planning(id) ON DELETE CASCADE,
     student_id BIGINT NOT NULL REFERENCES students(id) ON DELETE CASCADE,
     phase VARCHAR(100) NOT NULL,
-    exam_name_op1 VARCHAR(255),
-    op2_program_code VARCHAR(50),
-    surprise_assignment TEXT,
-    stars INTEGER,
     result VARCHAR(50),
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT exam_students_stars_check CHECK (stars IS NULL OR stars >= 0),
-    CONSTRAINT exam_students_exam_student_unique UNIQUE (exam_id, student_id)
+    CONSTRAINT exam_students_exam_student_unique UNIQUE (exam_planning_id, student_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_students_student_number
@@ -47,14 +26,8 @@ CREATE INDEX IF NOT EXISTS idx_students_student_number
 CREATE INDEX IF NOT EXISTS idx_students_program_code
     ON students (program_code);
 
-CREATE INDEX IF NOT EXISTS idx_exams_exam_date
-    ON exams (exam_date);
-
-CREATE INDEX IF NOT EXISTS idx_exams_exam_type
-    ON exams (exam_type);
-
-CREATE INDEX IF NOT EXISTS idx_exam_students_exam_id
-    ON exam_students (exam_id);
+CREATE INDEX IF NOT EXISTS idx_exam_students_exam_planning_id
+    ON exam_students (exam_planning_id);
 
 CREATE INDEX IF NOT EXISTS idx_exam_students_student_id
     ON exam_students (student_id);

--- a/Source/backend/db/migrations/004_add_updated_at_triggers.sql
+++ b/Source/backend/db/migrations/004_add_updated_at_triggers.sql
@@ -26,14 +26,6 @@ BEGIN
                  EXECUTE FUNCTION set_updated_at()';
     END IF;
 
-    IF to_regclass('public.exams') IS NOT NULL
-       AND NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'set_exams_updated_at') THEN
-        EXECUTE 'CREATE TRIGGER set_exams_updated_at
-                 BEFORE UPDATE ON exams
-                 FOR EACH ROW
-                 EXECUTE FUNCTION set_updated_at()';
-    END IF;
-
     IF to_regclass('public.exam_students') IS NOT NULL
        AND NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'set_exam_students_updated_at') THEN
         EXECUTE 'CREATE TRIGGER set_exam_students_updated_at

--- a/Source/backend/db/migrations/005_add_student_group_and_exam_assignments.sql
+++ b/Source/backend/db/migrations/005_add_student_group_and_exam_assignments.sql
@@ -1,0 +1,171 @@
+ALTER TABLE students
+    ADD COLUMN IF NOT EXISTS placement_group VARCHAR(100);
+
+CREATE TABLE IF NOT EXISTS products (
+    id BIGSERIAL PRIMARY KEY,
+    product_kind VARCHAR(50) NOT NULL,
+    speciality_code VARCHAR(50) NOT NULL,
+    speciality_name VARCHAR(255),
+    name VARCHAR(255) NOT NULL,
+    category VARCHAR(100),
+    stars INTEGER,
+    document_link TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT products_kind_check CHECK (product_kind IN ('regular', 'surprise')),
+    CONSTRAINT products_stars_check CHECK (stars IS NULL OR stars >= 0),
+    CONSTRAINT products_document_link_kind_check
+        CHECK (document_link IS NULL OR product_kind = 'surprise')
+);
+
+CREATE TABLE IF NOT EXISTS assessors (
+    id BIGSERIAL PRIMARY KEY,
+    assessor_type VARCHAR(30) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    organization VARCHAR(255),
+    salutation VARCHAR(100),
+    address TEXT,
+    postal_city VARCHAR(255),
+    phone VARCHAR(100),
+    email VARCHAR(255),
+    recruitment_status VARCHAR(100),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT assessors_type_check CHECK (assessor_type IN ('external', 'teacher'))
+);
+
+CREATE TABLE IF NOT EXISTS exam_assessors (
+    id BIGSERIAL PRIMARY KEY,
+    exam_planning_id BIGINT NOT NULL REFERENCES exam_planning(id) ON DELETE CASCADE,
+    assessor_id BIGINT NOT NULL REFERENCES assessors(id) ON DELETE RESTRICT,
+    assessor_order INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT exam_assessors_order_check CHECK (assessor_order IN (1, 2)),
+    CONSTRAINT exam_assessors_unique_slot UNIQUE (exam_planning_id, assessor_order),
+    CONSTRAINT exam_assessors_unique_assessor UNIQUE (exam_planning_id, assessor_id)
+);
+
+CREATE TABLE IF NOT EXISTS assignments (
+    id BIGSERIAL PRIMARY KEY,
+    exam_student_id BIGINT NOT NULL REFERENCES exam_students(id) ON DELETE CASCADE,
+    status VARCHAR(30) NOT NULL DEFAULT 'draft',
+    regular_stars INTEGER NOT NULL DEFAULT 0,
+    required_stars INTEGER NOT NULL DEFAULT 0,
+    total_stars INTEGER NOT NULL DEFAULT 0,
+    result VARCHAR(50),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT assignments_status_check
+        CHECK (status IN ('draft', 'confirmed', 'completed', 'cancelled')),
+    CONSTRAINT assignments_regular_stars_check CHECK (regular_stars >= 0),
+    CONSTRAINT assignments_required_stars_check CHECK (required_stars >= 0),
+    CONSTRAINT assignments_total_stars_check CHECK (total_stars >= 0),
+    CONSTRAINT assignments_exam_student_unique UNIQUE (exam_student_id)
+);
+
+CREATE TABLE IF NOT EXISTS assignment_products (
+    id BIGSERIAL PRIMARY KEY,
+    assignment_id BIGINT NOT NULL REFERENCES assignments(id) ON DELETE CASCADE,
+    product_id BIGINT REFERENCES products(id) ON DELETE SET NULL,
+    product_role VARCHAR(50) NOT NULL,
+    product_order INTEGER NOT NULL DEFAULT 1,
+    product_text TEXT,
+    stars INTEGER,
+    result VARCHAR(50),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT assignment_products_role_check
+        CHECK (product_role IN ('required', 'choice', 'surprise', 'bpv', 'practice_tool', 'custom')),
+    CONSTRAINT assignment_products_order_check CHECK (product_order > 0),
+    CONSTRAINT assignment_products_stars_check CHECK (stars IS NULL OR stars >= 0),
+    CONSTRAINT assignment_products_has_product
+        CHECK (product_id IS NOT NULL OR product_text IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_students_placement_group
+    ON students (placement_group);
+
+CREATE INDEX IF NOT EXISTS idx_products_speciality_kind
+    ON products (speciality_code, product_kind);
+
+CREATE INDEX IF NOT EXISTS idx_products_category
+    ON products (category);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_products_import_identity
+    ON products (product_kind, speciality_code, name);
+
+CREATE INDEX IF NOT EXISTS idx_assessors_type
+    ON assessors (assessor_type);
+
+CREATE INDEX IF NOT EXISTS idx_assessors_name
+    ON assessors (name);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_assessors_identity
+    ON assessors (assessor_type, name, COALESCE(email, ''));
+
+CREATE INDEX IF NOT EXISTS idx_exam_assessors_exam_planning_id
+    ON exam_assessors (exam_planning_id);
+
+CREATE INDEX IF NOT EXISTS idx_exam_assessors_assessor_id
+    ON exam_assessors (assessor_id);
+
+CREATE INDEX IF NOT EXISTS idx_assignments_exam_student_id
+    ON assignments (exam_student_id);
+
+CREATE INDEX IF NOT EXISTS idx_assignment_products_assignment_id
+    ON assignment_products (assignment_id);
+
+CREATE INDEX IF NOT EXISTS idx_assignment_products_product_id
+    ON assignment_products (product_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_assignment_products_unique_slot
+    ON assignment_products (assignment_id, product_role, product_order);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_assignment_products_unique_product
+    ON assignment_products (assignment_id, product_id)
+    WHERE product_id IS NOT NULL;
+
+DO $$
+BEGIN
+    IF to_regclass('public.products') IS NOT NULL
+       AND NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'set_products_updated_at') THEN
+        EXECUTE 'CREATE TRIGGER set_products_updated_at
+                 BEFORE UPDATE ON products
+                 FOR EACH ROW
+                 EXECUTE FUNCTION set_updated_at()';
+    END IF;
+
+    IF to_regclass('public.assessors') IS NOT NULL
+       AND NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'set_assessors_updated_at') THEN
+        EXECUTE 'CREATE TRIGGER set_assessors_updated_at
+                 BEFORE UPDATE ON assessors
+                 FOR EACH ROW
+                 EXECUTE FUNCTION set_updated_at()';
+    END IF;
+
+    IF to_regclass('public.exam_assessors') IS NOT NULL
+       AND NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'set_exam_assessors_updated_at') THEN
+        EXECUTE 'CREATE TRIGGER set_exam_assessors_updated_at
+                 BEFORE UPDATE ON exam_assessors
+                 FOR EACH ROW
+                 EXECUTE FUNCTION set_updated_at()';
+    END IF;
+
+    IF to_regclass('public.assignments') IS NOT NULL
+       AND NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'set_assignments_updated_at') THEN
+        EXECUTE 'CREATE TRIGGER set_assignments_updated_at
+                 BEFORE UPDATE ON assignments
+                 FOR EACH ROW
+                 EXECUTE FUNCTION set_updated_at()';
+    END IF;
+
+    IF to_regclass('public.assignment_products') IS NOT NULL
+       AND NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'set_assignment_products_updated_at') THEN
+        EXECUTE 'CREATE TRIGGER set_assignment_products_updated_at
+                 BEFORE UPDATE ON assignment_products
+                 FOR EACH ROW
+                 EXECUTE FUNCTION set_updated_at()';
+    END IF;
+END
+$$;

--- a/Source/backend/scripts/import_static_data.sh
+++ b/Source/backend/scripts/import_static_data.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${PROJECT_ROOT}/../.." && pwd)"
+COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
+REQUESTED_DB_MODE="${DB_MODE:-}"
+
+if [[ -f "${PROJECT_ROOT}/.env" ]]; then
+  # shellcheck disable=SC1091
+  source "${PROJECT_ROOT}/.env"
+fi
+
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5433}"
+PGUSER="${PGUSER:-exam_admin}"
+PGPASSWORD="${PGPASSWORD:-exam_admin}"
+PGDATABASE="${PGDATABASE:-exam_tool}"
+DB_MODE="${REQUESTED_DB_MODE:-${DB_MODE:-auto}}"
+STATIC_DATA_DIR="${STATIC_DATA_DIR:-${REPO_ROOT}/localfiles/output}"
+
+DB_MODE="$(printf '%s' "${DB_MODE}" | tr '[:upper:]' '[:lower:]')"
+
+students_file="${STATIC_DATA_DIR}/students_import_normalized_v2.csv"
+regular_products_file="${STATIC_DATA_DIR}/products_regular_import_normalized.csv"
+surprise_products_file="${STATIC_DATA_DIR}/products_surprise_import_normalized_v2.csv"
+assessors_file="${STATIC_DATA_DIR}/assessors_import_normalized_v2.csv"
+
+required_files=(
+  "${students_file}"
+  "${regular_products_file}"
+  "${surprise_products_file}"
+  "${assessors_file}"
+)
+
+for file in "${required_files[@]}"; do
+  if [[ ! -f "${file}" ]]; then
+    echo "Error: static import file not found: ${file}"
+    exit 1
+  fi
+done
+
+can_connect_local_postgres() {
+  PGPASSWORD="${PGPASSWORD}" psql \
+    --host "${PGHOST}" \
+    --port "${PGPORT}" \
+    --username "${PGUSER}" \
+    --dbname "${PGDATABASE}" \
+    --set ON_ERROR_STOP=1 \
+    --command "SELECT 1;" >/dev/null 2>&1
+}
+
+select_run_mode() {
+  case "${DB_MODE}" in
+    local)
+      if ! command -v psql >/dev/null 2>&1; then
+        echo "Error: DB_MODE=local but psql is not installed."
+        exit 1
+      fi
+      RUN_MODE="local"
+      export PGPASSWORD
+      ;;
+    docker)
+      RUN_MODE="docker"
+      ;;
+    auto)
+      if command -v psql >/dev/null 2>&1; then
+        export PGPASSWORD
+        if can_connect_local_postgres; then
+          RUN_MODE="local"
+        else
+          RUN_MODE="docker"
+        fi
+      else
+        RUN_MODE="docker"
+      fi
+      ;;
+    *)
+      echo "Error: invalid DB_MODE='${DB_MODE}'. Use: auto, local, or docker."
+      exit 1
+      ;;
+  esac
+}
+
+run_psql_command() {
+  if [[ "${RUN_MODE}" == "local" ]]; then
+    psql \
+      --host "${PGHOST}" \
+      --port "${PGPORT}" \
+      --username "${PGUSER}" \
+      --dbname "${PGDATABASE}" \
+      --set ON_ERROR_STOP=1 \
+      --command "$1"
+    return
+  fi
+
+  docker compose --file "${COMPOSE_FILE}" --project-directory "${PROJECT_ROOT}" exec -T postgres psql \
+    --username "${PGUSER}" \
+    --dbname "${PGDATABASE}" \
+    --set ON_ERROR_STOP=1 \
+    --command "$1"
+}
+
+copy_csv() {
+  local table_name="$1"
+  local columns="$2"
+  local csv_file="$3"
+
+  if [[ "${RUN_MODE}" == "local" ]]; then
+    psql \
+      --host "${PGHOST}" \
+      --port "${PGPORT}" \
+      --username "${PGUSER}" \
+      --dbname "${PGDATABASE}" \
+      --set ON_ERROR_STOP=1 \
+      --command "\\copy ${table_name} (${columns}) FROM STDIN WITH (FORMAT csv, HEADER true)" < "${csv_file}"
+    return
+  fi
+
+  docker compose --file "${COMPOSE_FILE}" --project-directory "${PROJECT_ROOT}" exec -T postgres psql \
+    --username "${PGUSER}" \
+    --dbname "${PGDATABASE}" \
+    --set ON_ERROR_STOP=1 \
+    --command "\\copy ${table_name} (${columns}) FROM STDIN WITH (FORMAT csv, HEADER true)" < "${csv_file}"
+}
+
+select_run_mode
+
+echo "Importing static data using run mode: ${RUN_MODE}"
+echo "Static data directory: ${STATIC_DATA_DIR}"
+
+run_psql_command "DROP TABLE IF EXISTS static_import_students;
+CREATE TABLE static_import_students (
+  student_number TEXT,
+  name TEXT,
+  program_code TEXT,
+  phase TEXT,
+  email TEXT,
+  placement_group TEXT
+);"
+copy_csv "static_import_students" "student_number, name, program_code, phase, email, placement_group" "${students_file}"
+run_psql_command "INSERT INTO students (student_number, name, program_code, phase, email, placement_group)
+SELECT student_number, name, program_code, phase, NULLIF(email, ''), NULLIF(placement_group, '')
+FROM static_import_students
+ON CONFLICT (student_number) DO UPDATE SET
+  name = EXCLUDED.name,
+  program_code = EXCLUDED.program_code,
+  phase = EXCLUDED.phase,
+  email = EXCLUDED.email,
+  placement_group = EXCLUDED.placement_group,
+  updated_at = NOW();"
+
+run_psql_command "DROP TABLE IF EXISTS static_import_products;
+CREATE TABLE static_import_products (
+  product_kind TEXT,
+  speciality_code TEXT,
+  speciality_name TEXT,
+  name TEXT,
+  category TEXT,
+  stars TEXT,
+  document_link TEXT
+);"
+copy_csv "static_import_products" "product_kind, speciality_code, speciality_name, name, category, stars, document_link" "${regular_products_file}"
+copy_csv "static_import_products" "product_kind, speciality_code, speciality_name, name, category, stars, document_link" "${surprise_products_file}"
+run_psql_command "INSERT INTO products (product_kind, speciality_code, speciality_name, name, category, stars, document_link)
+SELECT
+  product_kind,
+  speciality_code,
+  NULLIF(speciality_name, ''),
+  name,
+  NULLIF(category, ''),
+  NULLIF(stars, '')::INTEGER,
+  NULLIF(document_link, '')
+FROM static_import_products
+ON CONFLICT (product_kind, speciality_code, name) DO UPDATE SET
+  speciality_name = EXCLUDED.speciality_name,
+  category = EXCLUDED.category,
+  stars = EXCLUDED.stars,
+  document_link = EXCLUDED.document_link,
+  updated_at = NOW();"
+
+run_psql_command "DROP TABLE IF EXISTS static_import_assessors;
+CREATE TABLE static_import_assessors (
+  assessor_type TEXT,
+  name TEXT,
+  organization TEXT,
+  salutation TEXT,
+  address TEXT,
+  postal_city TEXT,
+  phone TEXT,
+  email TEXT,
+  recruitment_status TEXT
+);"
+copy_csv "static_import_assessors" "assessor_type, name, organization, salutation, address, postal_city, phone, email, recruitment_status" "${assessors_file}"
+run_psql_command "WITH source AS (
+  SELECT
+    assessor_type,
+    name,
+    NULLIF(organization, '') AS organization,
+    NULLIF(salutation, '') AS salutation,
+    NULLIF(address, '') AS address,
+    NULLIF(postal_city, '') AS postal_city,
+    NULLIF(phone, '') AS phone,
+    NULLIF(email, '') AS email,
+    NULLIF(recruitment_status, '') AS recruitment_status
+  FROM static_import_assessors
+)
+UPDATE assessors AS target
+SET
+  organization = source.organization,
+  salutation = source.salutation,
+  address = source.address,
+  postal_city = source.postal_city,
+  phone = source.phone,
+  recruitment_status = source.recruitment_status,
+  updated_at = NOW()
+FROM source
+WHERE target.assessor_type = source.assessor_type
+  AND target.name = source.name
+  AND COALESCE(target.email, '') = COALESCE(source.email, '');
+
+WITH source AS (
+  SELECT
+    assessor_type,
+    name,
+    NULLIF(organization, '') AS organization,
+    NULLIF(salutation, '') AS salutation,
+    NULLIF(address, '') AS address,
+    NULLIF(postal_city, '') AS postal_city,
+    NULLIF(phone, '') AS phone,
+    NULLIF(email, '') AS email,
+    NULLIF(recruitment_status, '') AS recruitment_status
+  FROM static_import_assessors
+)
+INSERT INTO assessors (
+  assessor_type,
+  name,
+  organization,
+  salutation,
+  address,
+  postal_city,
+  phone,
+  email,
+  recruitment_status
+)
+SELECT
+  source.assessor_type,
+  source.name,
+  source.organization,
+  source.salutation,
+  source.address,
+  source.postal_city,
+  source.phone,
+  source.email,
+  source.recruitment_status
+FROM source
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM assessors AS target
+  WHERE target.assessor_type = source.assessor_type
+    AND target.name = source.name
+    AND COALESCE(target.email, '') = COALESCE(source.email, '')
+);"
+
+run_psql_command "SELECT
+  (SELECT COUNT(*) FROM students) AS students,
+  (SELECT COUNT(*) FROM products WHERE product_kind = 'regular') AS regular_products,
+  (SELECT COUNT(*) FROM products WHERE product_kind = 'surprise') AS surprise_products,
+  (SELECT COUNT(*) FROM assessors) AS assessors;"
+
+run_psql_command "DROP TABLE IF EXISTS static_import_students;
+DROP TABLE IF EXISTS static_import_products;
+DROP TABLE IF EXISTS static_import_assessors;"
+
+echo "Static data import complete."

--- a/Source/backend/scripts/init_postgres.sh
+++ b/Source/backend/scripts/init_postgres.sh
@@ -11,7 +11,7 @@ if [[ -f "${PROJECT_ROOT}/.env" ]]; then
 fi
 
 PGHOST="${PGHOST:-localhost}"
-PGPORT="${PGPORT:-5432}"
+PGPORT="${PGPORT:-5433}"
 PGUSER="${PGUSER:-exam_admin}"
 PGPASSWORD="${PGPASSWORD:-exam_admin}"
 PGDATABASE="${PGDATABASE:-exam_tool}"
@@ -66,6 +66,22 @@ ensure_docker_postgres_running() {
   exit 1
 }
 
+wait_for_docker_postgres_ready() {
+  local attempts=30
+
+  while (( attempts > 0 )); do
+    if docker compose --file "${COMPOSE_FILE}" --project-directory "${PROJECT_ROOT}" exec -T postgres pg_isready -U "${PGUSER}" -d "${PGDATABASE}" >/dev/null 2>&1; then
+      return
+    fi
+
+    sleep 1
+    attempts=$((attempts - 1))
+  done
+
+  echo "Error: postgres container did not become ready in time."
+  exit 1
+}
+
 can_connect_local_postgres() {
   PGPASSWORD="${PGPASSWORD}" psql \
     --host "${PGHOST}" \
@@ -89,6 +105,7 @@ select_run_mode() {
     docker)
       RUN_MODE="docker"
       ensure_docker_postgres_running
+      wait_for_docker_postgres_ready
       ;;
     auto)
       if command -v psql >/dev/null 2>&1; then
@@ -100,10 +117,12 @@ select_run_mode() {
           echo "Falling back to docker compose service 'postgres'."
           RUN_MODE="docker"
           ensure_docker_postgres_running
+          wait_for_docker_postgres_ready
         fi
       else
         RUN_MODE="docker"
         ensure_docker_postgres_running
+        wait_for_docker_postgres_ready
       fi
       ;;
     *)

--- a/Source/backend/scripts/init_postgres.sh
+++ b/Source/backend/scripts/init_postgres.sh
@@ -17,9 +17,11 @@ PGPASSWORD="${PGPASSWORD:-exam_admin}"
 PGDATABASE="${PGDATABASE:-exam_tool}"
 DB_MODE="${DB_MODE:-auto}"
 DOCKER_AUTO_START="${DOCKER_AUTO_START:-true}"
+IMPORT_STATIC_DATA="${IMPORT_STATIC_DATA:-true}"
 
 DB_MODE="$(printf '%s' "${DB_MODE}" | tr '[:upper:]' '[:lower:]')"
 DOCKER_AUTO_START="$(printf '%s' "${DOCKER_AUTO_START}" | tr '[:upper:]' '[:lower:]')"
+IMPORT_STATIC_DATA="$(printf '%s' "${IMPORT_STATIC_DATA}" | tr '[:upper:]' '[:lower:]')"
 
 escape_sql_literal() {
   local value="$1"
@@ -238,5 +240,12 @@ for migration in "${migrations[@]}"; do
   mark_migration_applied "${migration_name}"
   echo "Applied ${migration_name}."
 done
+
+if [[ "${IMPORT_STATIC_DATA}" == "true" ]]; then
+  echo "Importing static reference data..."
+  DB_MODE="${RUN_MODE}" "${SCRIPT_DIR}/import_static_data.sh"
+else
+  echo "Skipping static reference data import."
+fi
 
 echo "Database initialization complete."


### PR DESCRIPTION
This pull request introduces major changes to the exam tool's backend database schema and setup scripts, focusing on normalization, static data import, and support for new entities such as products and assessors. It restructures core exam tables, adds new tables for assignments and products, and improves the initialization and import process for static reference data.

**Database schema changes and normalization:**

* Removed the `exams` table and migrated references in `exam_students` to use `exam_planning_id` instead, simplifying and normalizing the schema. Several columns related to assignments and stars were removed from `students` and `exam_students`, as these are now handled in new tables.
* Updated or removed related indexes and triggers to reflect the new schema, including removing exam-specific triggers and updating index references from `exam_id` to `exam_planning_id`. [[1]](diffhunk://#diff-21ef7e6f9ccf92196c0d97ce888148f895ac31b36b8add4e1406d8acbc16c4faL50-R30) [[2]](diffhunk://#diff-a6f919e553659328199b835611601f75b8838b46a7fc479cbd3c09bdce3b96faL29-L36)

**New tables and entities:**

* Added new tables: `products`, `assessors`, `exam_assessors`, `assignments`, and `assignment_products`, each with appropriate constraints, indexes, and triggers. These support the import and management of static reference data and the normalization of assignment and product relations.
* Added a `placement_group` column to `students` to support grouping logic.

**Static data import and initialization improvements:**

* Introduced the `import_static_data.sh` script, which imports students, products, and assessors from CSV files, supporting both local and Docker-based Postgres setups. The script handles upserts and ensures data consistency.
* Updated `init_postgres.sh` to support toggling static data import via the `IMPORT_STATIC_DATA` environment variable and to wait for the Postgres container to be ready before proceeding. [[1]](diffhunk://#diff-2fca2e7a799ae194d8961a069bf43b74361514d38161ec8fced8b02dc60c2929L14-R24) [[2]](diffhunk://#diff-2fca2e7a799ae194d8961a069bf43b74361514d38161ec8fced8b02dc60c2929R71-R86) [[3]](diffhunk://#diff-2fca2e7a799ae194d8961a069bf43b74361514d38161ec8fced8b02dc60c2929R110) [[4]](diffhunk://#diff-2fca2e7a799ae194d8961a069bf43b74361514d38161ec8fced8b02dc60c2929R122-R127) [[5]](diffhunk://#diff-2fca2e7a799ae194d8961a069bf43b74361514d38161ec8fced8b02dc60c2929R244-R250)

**Documentation updates:**

* Updated the backend `README.md` to document the new static data import process, including how to skip or re-run the import using the new scripts and environment variables.