### PR TITLE
Implement student management and exam planning features

### DIFF
--- a/Source/backend/app/api/router.py
+++ b/Source/backend/app/api/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 
 from app.api.routes.exam_planning import router as exam_planning_router
+from app.api.routes.exam_assessor import router as exam_assessor_router
 from app.api.routes.assessor import router as assessor_router
 from app.api.routes.auth import router as auth_router
 from app.api.routes.student import router as student_router
@@ -13,6 +14,7 @@ api_router = APIRouter()
 api_router.include_router(health_router)
 api_router.include_router(auth_router, prefix=settings.api_prefix)
 api_router.include_router(exam_student_router, prefix=settings.api_prefix, dependencies=[Depends(get_current_user)])
+api_router.include_router(exam_assessor_router, prefix=settings.api_prefix, dependencies=[Depends(get_current_user)])
 api_router.include_router(exam_planning_router, prefix=settings.api_prefix, dependencies=[Depends(get_current_user)])
 api_router.include_router(assessor_router, prefix=settings.api_prefix, dependencies=[Depends(get_current_user)])
 api_router.include_router(student_router, prefix=settings.api_prefix, dependencies=[Depends(get_current_user)])

--- a/Source/backend/app/api/routes/exam_assessor.py
+++ b/Source/backend/app/api/routes/exam_assessor.py
@@ -1,0 +1,79 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.models.assessor import ExamAssessor
+from app.schemas.assessor import ExamAssessorCreate, ExamAssessorRead
+
+router = APIRouter(prefix="/exam-assessors", tags=["exam-assessors"])
+
+
+@router.post("", response_model=ExamAssessorRead, status_code=status.HTTP_201_CREATED)
+def create_exam_assessor(payload: ExamAssessorCreate, db: Session = Depends(get_db)) -> ExamAssessor:
+    if payload.exam_planning_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="exam_planning_id is required",
+        )
+
+    exam_assessor = ExamAssessor(
+        exam_planning_id=payload.exam_planning_id,
+        assessor_id=payload.assessor_id,
+        assessor_order=payload.assessor_order,
+    )
+
+    db.add(exam_assessor)
+
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Assessor is already linked to this exam slot",
+        ) from exc
+
+    db.refresh(exam_assessor)
+    return exam_assessor
+
+
+@router.get("", response_model=list[ExamAssessorRead])
+def list_exam_assessors(
+    exam_planning_id: Optional[int] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    db: Session = Depends(get_db),
+) -> list[ExamAssessor]:
+    query = select(ExamAssessor)
+
+    if exam_planning_id is not None:
+        query = query.where(ExamAssessor.exam_planning_id == exam_planning_id)
+
+    query = query.order_by(ExamAssessor.assessor_order.asc()).limit(limit).offset(offset)
+    items = db.execute(query).scalars().all()
+    return list(items)
+
+
+@router.get("/{exam_assessor_id}", response_model=ExamAssessorRead)
+def get_exam_assessor(exam_assessor_id: int, db: Session = Depends(get_db)) -> ExamAssessor:
+    exam_assessor = db.get(ExamAssessor, exam_assessor_id)
+
+    if exam_assessor is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Exam-assessor link not found")
+
+    return exam_assessor
+
+
+@router.delete("/{exam_assessor_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_exam_assessor(exam_assessor_id: int, db: Session = Depends(get_db)) -> None:
+    exam_assessor = db.get(ExamAssessor, exam_assessor_id)
+
+    if exam_assessor is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Exam-assessor link not found")
+
+    db.delete(exam_assessor)
+    db.commit()

--- a/Source/backend/app/api/routes/exam_planning.py
+++ b/Source/backend/app/api/routes/exam_planning.py
@@ -6,8 +6,8 @@ from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.models.exam_planning import Base, ExamPlanning
-from app.models.assessor import ExamAssessor
-from app.models.exam_student import ExamStudent
+
+
 from app.schemas.exam_planning import ExamPlanningCreate, ExamPlanningRead, ExamPlanningUpdate
 
 
@@ -33,29 +33,6 @@ def create_exam_planning(payload: ExamPlanningCreate, db: Session = Depends(get_
     )
 
     db.add(item)
-    db.flush()  # Flush to get the ID without committing
-
-    # Add assessors if provided
-    if payload.assessors:
-        for assessor_data in payload.assessors:
-            exam_assessor = ExamAssessor(
-                exam_planning_id=item.id,
-                assessor_id=assessor_data.assessor_id,
-                assessor_order=assessor_data.assessor_order,
-            )
-            db.add(exam_assessor)
-
-    # Add students if provided
-    if payload.students:
-        for student_data in payload.students:
-            exam_student = ExamStudent(
-                exam_planning_id=item.id,
-                student_id=student_data.student_id,
-                phase=student_data.phase,
-                result=student_data.result,
-            )
-            db.add(exam_student)
-
     db.commit()
     db.refresh(item)
     return item
@@ -72,40 +49,10 @@ def update_exam_planning(
     if item is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Exam planning not found")
 
-    # Update basic fields
-    updates = payload.model_dump(exclude_unset=True, exclude={"assessors", "students"})
+    updates = payload.model_dump(exclude_unset=True)
 
     for field, value in updates.items():
         setattr(item, field, value)
-
-    # Handle assessors update if provided
-    if payload.assessors is not None:
-        # Delete existing assessors
-        db.query(ExamAssessor).filter(ExamAssessor.exam_planning_id == exam_id).delete()
-
-        # Add new assessors
-        for assessor_data in payload.assessors:
-            exam_assessor = ExamAssessor(
-                exam_planning_id=exam_id,
-                assessor_id=assessor_data.assessor_id,
-                assessor_order=assessor_data.assessor_order,
-            )
-            db.add(exam_assessor)
-
-    # Handle students update if provided
-    if payload.students is not None:
-        # Delete existing students
-        db.query(ExamStudent).filter(ExamStudent.exam_planning_id == exam_id).delete()
-
-        # Add new students
-        for student_data in payload.students:
-            exam_student = ExamStudent(
-                exam_planning_id=exam_id,
-                student_id=student_data.student_id,
-                phase=student_data.phase,
-                result=student_data.result,
-            )
-            db.add(exam_student)
 
     db.commit()
     db.refresh(item)

--- a/Source/backend/app/schemas/assessor.py
+++ b/Source/backend/app/schemas/assessor.py
@@ -49,6 +49,7 @@ class AssessorRead(BaseModel):
 
 
 class ExamAssessorCreate(BaseModel):
+    exam_planning_id: Optional[int] = None
     assessor_id: int
     assessor_order: int = Field(ge=1, le=2)
 
@@ -57,6 +58,7 @@ class ExamAssessorRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
+    exam_planning_id: int
     assessor_id: int
     assessor_order: int
     assessor: AssessorRead

--- a/Source/backend/app/schemas/exam_planning.py
+++ b/Source/backend/app/schemas/exam_planning.py
@@ -3,8 +3,8 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.schemas.assessor import ExamAssessorRead, ExamAssessorCreate
-from app.schemas.exam_student import ExamStudentCreate, ExamStudentRead
+from app.schemas.assessor import ExamAssessorRead
+from app.schemas.exam_student import ExamStudentRead
 
 
 PlanningStatus = Literal["planned", "confirmed", "completed", "cancelled"]
@@ -17,8 +17,6 @@ class ExamPlanningCreate(BaseModel):
     room: str = Field(min_length=1, max_length=100)
     exam_time: time
     status: PlanningStatus = "planned"
-    assessors: Optional[list[ExamAssessorCreate]] = Field(default=None)
-    students: Optional[list[ExamStudentCreate]] = Field(default=None)
 
 
 class ExamPlanningUpdate(BaseModel):
@@ -27,8 +25,6 @@ class ExamPlanningUpdate(BaseModel):
     room: Optional[str] = Field(default=None, min_length=1, max_length=100)
     exam_time: Optional[time] = None
     status: Optional[PlanningStatus] = None
-    assessors: Optional[list[ExamAssessorCreate]] = None
-    students: Optional[list[ExamStudentCreate]] = None
 
 
 class ExamPlanningRead(BaseModel):

--- a/Source/backend/app/schemas/exam_student.py
+++ b/Source/backend/app/schemas/exam_student.py
@@ -9,12 +9,12 @@ from app.schemas.student import StudentRead
 class ExamStudentCreate(BaseModel):
     exam_planning_id: int
     student_id: int
-    phase: str = Field(min_length=1, max_length=100)
+    phase: str = Field(default="", max_length=100)
     result: Optional[str] = Field(default=None, max_length=50)
 
 
 class ExamStudentUpdate(BaseModel):
-    phase: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    phase: Optional[str] = Field(default=None, max_length=100)
     result: Optional[str] = Field(default=None, max_length=50)
 
 

--- a/Source/frontend/src/services/examAssessorsApi.js
+++ b/Source/frontend/src/services/examAssessorsApi.js
@@ -1,0 +1,13 @@
+import { request } from './apiClient'
+
+export const listExamAssessors = ({ exam_planning_id = null, limit = 500, offset = 0 } = {}) => {
+  const query = { limit, offset }
+  if (exam_planning_id) query.exam_planning_id = exam_planning_id
+  return request('/exam-assessors', { query })
+}
+
+export const getExamAssessor = (id) => request(`/exam-assessors/${id}`)
+
+export const createExamAssessor = (payload) => request('/exam-assessors', { method: 'POST', body: payload })
+
+export const deleteExamAssessor = (id) => request(`/exam-assessors/${id}`, { method: 'DELETE' })

--- a/Source/frontend/src/services/examStudentsApi.js
+++ b/Source/frontend/src/services/examStudentsApi.js
@@ -1,0 +1,20 @@
+import { request } from './apiClient'
+
+export const listExamStudents = ({ exam_planning_id = null, student_id = null, limit = 500, offset = 0 } = {}) => {
+  const query = { limit, offset }
+  if (exam_planning_id) query.exam_planning_id = exam_planning_id
+  if (student_id) query.student_id = student_id
+  return request('/exam-students', { query })
+}
+
+export const createExamStudent = (payload) => {
+  return request('/exam-students', { method: 'POST', body: payload })
+}
+
+export const updateExamStudent = (id, payload) => {
+  return request(`/exam-students/${id}`, { method: 'PATCH', body: payload })
+}
+
+export const deleteExamStudent = (id) => {
+  return request(`/exam-students/${id}`, { method: 'DELETE' })
+}

--- a/Source/frontend/src/views/ExamensView.vue
+++ b/Source/frontend/src/views/ExamensView.vue
@@ -6,6 +6,7 @@ import { listExamPlanning, updateExamPlanning, deleteExamPlanning } from '../ser
 import { listAssessors } from '../services/assessorsApi'
 import { listStudents } from '../services/studentsApi'
 import { createExamStudent, deleteExamStudent } from '../services/examStudentsApi'
+import { createExamAssessor, deleteExamAssessor } from '../services/examAssessorsApi'
 
 const route = useRoute()
 const router = useRouter()
@@ -66,8 +67,6 @@ const editForm = reactive({
   room: '',
   exam_type: 'practical',
   status: 'planned',
-  assessor_slot_1: null,
-  assessor_slot_2: null,
 })
 
 const assessorsOptions = ref([])
@@ -84,16 +83,6 @@ watch(selectedExam, (exam) => {
     editForm.room = exam.room || ''
     editForm.exam_type = exam.exam_type || 'practical'
     editForm.status = exam.status || 'planned'
-
-    // populate assessor slots from exam_assessors
-    editForm.assessor_slot_1 = null
-    editForm.assessor_slot_2 = null
-    if (Array.isArray(exam.exam_assessors)) {
-      for (const ea of exam.exam_assessors) {
-        if (ea.assessor_order === 1) editForm.assessor_slot_1 = ea.assessor.id
-        if (ea.assessor_order === 2) editForm.assessor_slot_2 = ea.assessor.id
-      }
-    }
 
   }
 })
@@ -144,16 +133,6 @@ const cancelEdit = () => {
     editForm.exam_type = selectedExam.value.exam_type
     editForm.status = selectedExam.value.status
 
-    // reset assessor slots
-    editForm.assessor_slot_1 = null
-    editForm.assessor_slot_2 = null
-    if (Array.isArray(selectedExam.value.exam_assessors)) {
-      for (const ea of selectedExam.value.exam_assessors) {
-        if (ea.assessor_order === 1) editForm.assessor_slot_1 = ea.assessor.id
-        if (ea.assessor_order === 2) editForm.assessor_slot_2 = ea.assessor.id
-      }
-    }
-
   }
 }
 
@@ -170,13 +149,6 @@ const saveEdit = async () => {
       exam_type: editForm.exam_type,
       status: editForm.status,
     }
-
-    // build assessors array if any selected
-    const assessorsPayload = []
-    if (editForm.assessor_slot_1) assessorsPayload.push({ assessor_id: Number(editForm.assessor_slot_1), assessor_order: 1 })
-    if (editForm.assessor_slot_2) assessorsPayload.push({ assessor_id: Number(editForm.assessor_slot_2), assessor_order: 2 })
-
-    payload.assessors = assessorsPayload
 
     await updateExamPlanning(selectedExam.value.id, payload)
     await loadExamPlanning()
@@ -280,6 +252,56 @@ const unlinkStudent = async (examStudentId) => {
     console.error(e)
   } finally {
     studentActionLoading.value = false
+  }
+}
+
+const assessorActionLoading = ref(false)
+
+const getSlotAssessorId = (slotOrder) => {
+  if (!selectedExam.value) return null
+  const ea = (selectedExam.value.exam_assessors || []).find((ea) => ea.assessor_order === slotOrder)
+  return ea ? ea.assessor_id : null
+}
+
+const onSlotChange = async (slotOrder, event) => {
+  const newAssessorId = event.target.value ? Number(event.target.value) : null
+  if (!selectedExam.value) return
+  assessorActionLoading.value = true
+  try {
+    const current = (selectedExam.value.exam_assessors || []).find((ea) => ea.assessor_order === slotOrder)
+    if (newAssessorId) {
+      if (current) {
+        await deleteExamAssessor(current.id)
+      }
+      await createExamAssessor({
+        exam_planning_id: selectedExam.value.id,
+        assessor_id: newAssessorId,
+        assessor_order: slotOrder,
+      })
+    } else if (current) {
+      await deleteExamAssessor(current.id)
+    }
+    await loadExamPlanning()
+    router.replace({ name: 'examens', query: { exam: selectedExam.value.id } })
+  } catch (e) {
+    console.error(e)
+  } finally {
+    assessorActionLoading.value = false
+  }
+}
+
+const unlinkAssessor = async (examAssessorId) => {
+  assessorActionLoading.value = true
+  try {
+    await deleteExamAssessor(examAssessorId)
+    await loadExamPlanning()
+    if (selectedExam.value) {
+      router.replace({ name: 'examens', query: { exam: selectedExam.value.id } })
+    }
+  } catch (e) {
+    console.error(e)
+  } finally {
+    assessorActionLoading.value = false
   }
 }
 </script>
@@ -401,46 +423,21 @@ const unlinkStudent = async (examStudentId) => {
           <div class="detail-section">
             <h3>Beoordelaars</h3>
 
-            <div v-if="!isEditing">
-              <div v-if="selectedExam.exam_assessors && selectedExam.exam_assessors.length">
-                <ul style="list-style:none; padding:0; display:flex; gap:0.75rem; flex-direction:row">
-                  <li v-for="ea in selectedExam.exam_assessors" :key="ea.id">
-                    <div style="padding:0.5rem 0.75rem; border-radius:0.6rem; background:#f8fafc; border:1px solid #e5e7eb">
-                      <div style="font-weight:600">{{ ea.assessor.name }}</div>
-                      <div style="font-size:0.85rem; color:#6b7280">{{ ea.assessor.organization || '—' }} · Slot {{ ea.assessor_order }}</div>
-                    </div>
-                  </li>
-                </ul>
-              </div>
-              <div v-else>
-                <p class="placeholder-copy">Nog geen beoordelaars toegewezen.</p>
-              </div>
-            </div>
-
-            <div v-else style="display:flex; flex-direction:column; gap:0.6rem; align-items:flex-start; width:100%">
-              <div style="display:flex; gap:0.6rem; width:100%">
-                <label style="flex:1">
-                  <span>Beoordelaar slot 1</span>
-                  <select v-model="editForm.assessor_slot_1">
-                    <option :value="null">— Geen —</option>
-                    <option v-for="a in assessorsOptions" :key="a.id" :value="a.id" :disabled="editForm.assessor_slot_2 && Number(editForm.assessor_slot_2) === a.id">
-                      {{ a.name }}{{ a.organization ? ' · ' + a.organization : '' }}
-                    </option>
-                  </select>
-                </label>
-
-                <label style="flex:1">
-                  <span>Beoordelaar slot 2</span>
-                  <select v-model="editForm.assessor_slot_2">
-                    <option :value="null">— Geen —</option>
-                    <option v-for="a in assessorsOptions" :key="a.id" :value="a.id" :disabled="editForm.assessor_slot_1 && Number(editForm.assessor_slot_1) === a.id">
-                      {{ a.name }}{{ a.organization ? ' · ' + a.organization : '' }}
-                    </option>
-                  </select>
-                </label>
-              </div>
-
-              <p v-if="saveError" class="panel-error">{{ saveError }}</p>
+            <div style="display:flex; gap:0.6rem; width:100%">
+              <label style="flex:1; display:flex; flex-direction:column; gap:0.25rem">
+                <span style="font-size:0.85rem; color:#6b7280">Slot 1</span>
+                <select style="border:1px solid #d1d5db; border-radius:0.5rem; padding:0.45rem 0.55rem; font-size:0.9rem" :value="getSlotAssessorId(1)" :disabled="assessorActionLoading" @change="onSlotChange(1, $event)">
+                  <option value="">— Geen —</option>
+                  <option v-for="a in assessorsOptions" :key="a.id" :value="a.id" :disabled="getSlotAssessorId(2) === a.id">{{ a.name }}{{ a.organization ? ' · ' + a.organization : '' }}</option>
+                </select>
+              </label>
+              <label style="flex:1; display:flex; flex-direction:column; gap:0.25rem">
+                <span style="font-size:0.85rem; color:#6b7280">Slot 2</span>
+                <select style="border:1px solid #d1d5db; border-radius:0.5rem; padding:0.45rem 0.55rem; font-size:0.9rem" :value="getSlotAssessorId(2)" :disabled="assessorActionLoading" @change="onSlotChange(2, $event)">
+                  <option value="">— Geen —</option>
+                  <option v-for="a in assessorsOptions" :key="a.id" :value="a.id" :disabled="getSlotAssessorId(1) === a.id">{{ a.name }}{{ a.organization ? ' · ' + a.organization : '' }}</option>
+                </select>
+              </label>
             </div>
           </div>
 

--- a/Source/frontend/src/views/ExamensView.vue
+++ b/Source/frontend/src/views/ExamensView.vue
@@ -4,6 +4,8 @@ import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { eventTypes, examStatusLabels } from '../constants/dashboard'
 import { listExamPlanning, updateExamPlanning, deleteExamPlanning } from '../services/examPlanningApi'
 import { listAssessors } from '../services/assessorsApi'
+import { listStudents } from '../services/studentsApi'
+import { createExamStudent, deleteExamStudent } from '../services/examStudentsApi'
 
 const route = useRoute()
 const router = useRouter()
@@ -69,6 +71,7 @@ const editForm = reactive({
 })
 
 const assessorsOptions = ref([])
+const studentsOptions = ref([])
 
 watch(selectedExam, (exam) => {
   isEditing.value = false
@@ -91,6 +94,7 @@ watch(selectedExam, (exam) => {
         if (ea.assessor_order === 2) editForm.assessor_slot_2 = ea.assessor.id
       }
     }
+
   }
 })
 
@@ -98,8 +102,15 @@ const loadAssessors = async () => {
   try {
     assessorsOptions.value = await listAssessors({ limit: 500 })
   } catch (e) {
-    // ignore silently for now
     assessorsOptions.value = []
+  }
+}
+
+const loadStudents = async () => {
+  try {
+    studentsOptions.value = await listStudents({ limit: 500 })
+  } catch (e) {
+    studentsOptions.value = []
   }
 }
 
@@ -142,6 +153,7 @@ const cancelEdit = () => {
         if (ea.assessor_order === 2) editForm.assessor_slot_2 = ea.assessor.id
       }
     }
+
   }
 }
 
@@ -164,7 +176,6 @@ const saveEdit = async () => {
     if (editForm.assessor_slot_1) assessorsPayload.push({ assessor_id: Number(editForm.assessor_slot_1), assessor_order: 1 })
     if (editForm.assessor_slot_2) assessorsPayload.push({ assessor_id: Number(editForm.assessor_slot_2), assessor_order: 2 })
 
-    // include assessors key even if empty to clear assignments
     payload.assessors = assessorsPayload
 
     await updateExamPlanning(selectedExam.value.id, payload)
@@ -224,8 +235,53 @@ watch(
 )
 
 onMounted(async () => {
-  await Promise.all([loadExamPlanning(), loadAssessors()])
+  await Promise.all([loadExamPlanning(), loadAssessors(), loadStudents()])
 })
+
+const linkingStudentId = ref(null)
+const studentActionLoading = ref(false)
+
+const availableStudents = computed(() => {
+  if (!selectedExam.value) return studentsOptions.value
+  const linkedIds = new Set(
+    (selectedExam.value.exam_students || []).map((es) => es.student_id)
+  )
+  return studentsOptions.value.filter((s) => !linkedIds.has(s.id))
+})
+
+const linkStudent = async () => {
+  if (!linkingStudentId.value || !selectedExam.value) return
+  studentActionLoading.value = true
+  try {
+    await createExamStudent({
+      exam_planning_id: selectedExam.value.id,
+      student_id: linkingStudentId.value,
+      phase: '',
+    })
+    linkingStudentId.value = null
+    await loadExamPlanning()
+    router.replace({ name: 'examens', query: { exam: selectedExam.value.id } })
+  } catch (e) {
+    console.error(e)
+  } finally {
+    studentActionLoading.value = false
+  }
+}
+
+const unlinkStudent = async (examStudentId) => {
+  studentActionLoading.value = true
+  try {
+    await deleteExamStudent(examStudentId)
+    await loadExamPlanning()
+    if (selectedExam.value) {
+      router.replace({ name: 'examens', query: { exam: selectedExam.value.id } })
+    }
+  } catch (e) {
+    console.error(e)
+  } finally {
+    studentActionLoading.value = false
+  }
+}
 </script>
 
 <template>
@@ -235,7 +291,7 @@ onMounted(async () => {
         <p class="eyebrow">Examens</p>
         <h1>Overzicht van geplande examens</h1>
         <p class="hero-copy">
-          Selecteer een examen uit de lijst om de detailpagina te openen. De toegewezen studentenlijst komt hier later.
+          Selecteer een examen uit de lijst om de detailpagina te openen.
         </p>
       </div>
 
@@ -390,12 +446,28 @@ onMounted(async () => {
 
           <div class="detail-section">
             <h3>Toegewezen studenten</h3>
-            <p class="placeholder-copy">
-              Deze lijst wordt later toegevoegd zodra studenttoewijzingen beschikbaar zijn.
-            </p>
-            <div class="placeholder-box">
-              <span>Voorbeeld</span>
-              <p>Hier komt een lijst met studenten die aan dit examen zijn gekoppeld.</p>
+
+            <div v-if="selectedExam.exam_students && selectedExam.exam_students.length">
+              <ul style="list-style:none; padding:0; display:flex; flex-direction:column; gap:0.5rem">
+                <li v-for="es in selectedExam.exam_students" :key="es.id" style="display:flex; justify-content:space-between; align-items:center; padding:0.5rem 0.75rem; border-radius:0.6rem; background:#f8fafc; border:1px solid #e5e7eb">
+                  <div>
+                    <div style="font-weight:600">{{ es.student.name }}</div>
+                    <div style="font-size:0.85rem; color:#6b7280">{{ es.student.student_number }}</div>
+                  </div>
+                  <button type="button" style="border:none; background:none; cursor:pointer; font-size:1.1rem; color:#b91c1c; padding:0.25rem" :disabled="studentActionLoading" @click="unlinkStudent(es.id)">×</button>
+                </li>
+              </ul>
+            </div>
+            <div v-else>
+              <p class="placeholder-copy">Nog geen studenten toegewezen.</p>
+            </div>
+
+            <div style="display:flex; gap:0.5rem; margin-top:0.75rem; align-items:center">
+              <select v-model="linkingStudentId" style="flex:1; border:1px solid #d1d5db; border-radius:0.5rem; padding:0.45rem 0.55rem; font-size:0.9rem">
+                <option :value="null">— Voeg student toe —</option>
+                <option v-for="s in availableStudents" :key="s.id" :value="s.id">{{ s.name }} · {{ s.student_number }}</option>
+              </select>
+              <button class="btn-secondary" type="button" style="padding:0.45rem 0.7rem; font-size:0.85rem" :disabled="!linkingStudentId || studentActionLoading" @click="linkStudent">Toevoegen</button>
             </div>
           </div>
         </div>

--- a/Source/frontend/src/views/ExamensView.vue
+++ b/Source/frontend/src/views/ExamensView.vue
@@ -5,7 +5,7 @@ import { eventTypes, examStatusLabels } from '../constants/dashboard'
 import { listExamPlanning, updateExamPlanning, deleteExamPlanning } from '../services/examPlanningApi'
 import { listAssessors } from '../services/assessorsApi'
 import { listStudents } from '../services/studentsApi'
-import { createExamStudent, deleteExamStudent } from '../services/examStudentsApi'
+import { createExamStudent, updateExamStudent, deleteExamStudent } from '../services/examStudentsApi'
 import { createExamAssessor, deleteExamAssessor } from '../services/examAssessorsApi'
 
 const route = useRoute()
@@ -240,6 +240,18 @@ const linkStudent = async () => {
   }
 }
 
+const updateStudentField = async (examStudentId, field, value) => {
+  try {
+    await updateExamStudent(examStudentId, { [field]: value })
+    await loadExamPlanning()
+    if (selectedExam.value) {
+      router.replace({ name: 'examens', query: { exam: selectedExam.value.id } })
+    }
+  } catch (e) {
+    console.error(e)
+  }
+}
+
 const unlinkStudent = async (examStudentId) => {
   studentActionLoading.value = true
   try {
@@ -444,16 +456,37 @@ const unlinkAssessor = async (examAssessorId) => {
           <div class="detail-section">
             <h3>Toegewezen studenten</h3>
 
-            <div v-if="selectedExam.exam_students && selectedExam.exam_students.length">
-              <ul style="list-style:none; padding:0; display:flex; flex-direction:column; gap:0.5rem">
-                <li v-for="es in selectedExam.exam_students" :key="es.id" style="display:flex; justify-content:space-between; align-items:center; padding:0.5rem 0.75rem; border-radius:0.6rem; background:#f8fafc; border:1px solid #e5e7eb">
-                  <div>
-                    <div style="font-weight:600">{{ es.student.name }}</div>
-                    <div style="font-size:0.85rem; color:#6b7280">{{ es.student.student_number }}</div>
-                  </div>
-                  <button type="button" style="border:none; background:none; cursor:pointer; font-size:1.1rem; color:#b91c1c; padding:0.25rem" :disabled="studentActionLoading" @click="unlinkStudent(es.id)">×</button>
-                </li>
-              </ul>
+            <div v-if="selectedExam.exam_students && selectedExam.exam_students.length" style="overflow-x:auto">
+              <table style="width:100%; border-collapse:collapse; font-size:0.9rem">
+                <thead>
+                  <tr style="border-bottom:2px solid #e5e7eb">
+                    <th style="text-align:left; padding:0.5rem 0.75rem; color:#6b7280; font-weight:600">Naam</th>
+                    <th style="text-align:left; padding:0.5rem 0.75rem; color:#6b7280; font-weight:600">SchoolID</th>
+                    <th style="text-align:left; padding:0.5rem 0.75rem; color:#6b7280; font-weight:600">Opdracht</th>
+                    <th style="text-align:left; padding:0.5rem 0.75rem; color:#6b7280; font-weight:600">Resultaat</th>
+                    <th style="padding:0.5rem 0.75rem; width:40px"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="es in selectedExam.exam_students" :key="es.id" style="border-bottom:1px solid #f3f4f6">
+                    <td style="padding:0.5rem 0.75rem; font-weight:600">{{ es.student.name }}</td>
+                    <td style="padding:0.5rem 0.75rem; color:#6b7280">{{ es.student.student_number }}</td>
+                    <td style="padding:0.35rem 0.75rem">
+                      <div style="display:flex; align-items:center; gap:0.4rem">
+                        <span style="font-size:0.85rem; color:#374151">—</span>
+                        <button type="button" style="border:1px solid #d1d5db; border-radius:0.4rem; padding:0.25rem 0.5rem; font-size:0.8rem; background:#fff; cursor:pointer; color:#374151">Bekijken</button>
+                        <button type="button" style="border:1px solid #d1d5db; border-radius:0.4rem; padding:0.25rem 0.5rem; font-size:0.8rem; background:#fff; cursor:pointer; color:#374151; white-space:nowrap">Toewijzen</button>
+                      </div>
+                    </td>
+                    <td style="padding:0.35rem 0.75rem">
+                      <input type="text" :value="es.result || ''" @blur="updateStudentField(es.id, 'result', $event.target.value || null)" style="width:100%; min-width:80px; border:1px solid #d1d5db; border-radius:0.4rem; padding:0.35rem 0.5rem; font-size:0.85rem; background:#fff" placeholder="—" />
+                    </td>
+                    <td style="padding:0.5rem 0.75rem">
+                      <button type="button" style="border:none; background:none; cursor:pointer; font-size:1.1rem; color:#b91c1c; padding:0.25rem" :disabled="studentActionLoading" @click="unlinkStudent(es.id)">×</button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
             <div v-else>
               <p class="placeholder-copy">Nog geen studenten toegewezen.</p>


### PR DESCRIPTION
This pull request refactors how exam assessors and students are managed for exam planning, moving their creation, updating, and deletion to dedicated API endpoints and decoupling them from the main exam planning logic. It introduces new backend API routes and frontend service functions for exam assessors and exam students, and updates the frontend to use these endpoints for real-time linking and unlinking of assessors and students. This results in a more modular, maintainable, and RESTful design.

**Backend API changes:**

- **Exam Assessor API endpoints**
  - Added a new `exam_assessor` router with endpoints to create, list, retrieve, and delete exam-assessor links (`exam_assessor.py`). These endpoints handle linking assessors to exam slots and enforce uniqueness. (`[Source/backend/app/api/routes/exam_assessor.pyR1-R79](diffhunk://#diff-eb63ddc4b7cdfbef7c41b0e50d02042782d2d4b6c4b0d46ae9f7d8fb138691a2R1-R79)`)
  - Registered the new `exam_assessor` router in the main API router. (`[[1]](diffhunk://#diff-aad1c0644eeb8339dec620e4cd4092b2df156e37d4342eb98a17ff2169204c36R4)`, `[[2]](diffhunk://#diff-aad1c0644eeb8339dec620e4cd4092b2df156e37d4342eb98a17ff2169204c36R17)`)

- **Exam Planning logic simplification**
  - Removed logic for creating, updating, and deleting exam assessors and students directly from the exam planning create/update endpoints. Now, exam planning only handles its own fields, and linking assessors/students is done via their dedicated endpoints. (`[[1]](diffhunk://#diff-a0b4f102013ae7da9e2cbe0ccf60869f7ed54e65e11113fbe00cf0364986f65dL36-L58)`, `[[2]](diffhunk://#diff-a0b4f102013ae7da9e2cbe0ccf60869f7ed54e65e11113fbe00cf0364986f65dL75-L109)`)
  - Updated `ExamPlanningCreate` and `ExamPlanningUpdate` schemas to remove `assessors` and `students` fields. (`[[1]](diffhunk://#diff-7d4ee0efcedd4271d323e6e564215dd61402561886c2c605468ab8faef74956aL20-L21)`, `[[2]](diffhunk://#diff-7d4ee0efcedd4271d323e6e564215dd61402561886c2c605468ab8faef74956aL30-L31)`)

- **Schema adjustments**
  - Updated `ExamAssessorCreate` to allow an optional `exam_planning_id`, and `ExamAssessorRead` to include `exam_planning_id`. (`[[1]](diffhunk://#diff-6bcd41997a4c1fe0b7735751b53ddcce8624b3ce5f63bac6175afdeda4fc5971R52)`, `[[2]](diffhunk://#diff-6bcd41997a4c1fe0b7735751b53ddcce8624b3ce5f63bac6175afdeda4fc5971R61)`)
  - Adjusted `ExamStudentCreate` and `ExamStudentUpdate` to make `phase` optional or default to an empty string. (`[Source/backend/app/schemas/exam_student.pyL12-R17](diffhunk://#diff-0c2ff2a4159edf450557d14ee1e50cbe0c727988a11f420e17252103e3e80660L12-R17)`)

**Frontend changes:**

- **API service modules**
  - Added `examAssessorsApi.js` and `examStudentsApi.js` with functions to list, create, update, and delete exam-assessor and exam-student links. (`[[1]](diffhunk://#diff-5a8bc40a1e7eec598310118cfb1b7e0c7e1b0b1343fdd228ffe93c12fdc6b305R1-R13)`, `[[2]](diffhunk://#diff-c98828cbae63bf84337a35744a10b7d0f2851f9b126a546fceadfb4bffbc1581R1-R20)`)

- **ExamensView refactor**
  - Refactored the exam detail view to fetch assessors and students lists for selection, and to use the new endpoints for linking/unlinking assessors and students in real time. This replaces the previous form-based approach with slot-based dropdowns and action buttons. (`[[1]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaR7-R9)`, `[[2]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL67-R73)`, `[[3]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL85-R105)`, `[[4]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL136-L144)`, `[[5]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL162-L169)`, `[[6]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL227-R318)`, `[[7]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL238-R328)`)

**Summary of most important changes:**

**Backend: API and logic refactor**
- Added new REST API endpoints for exam-assessor management (`exam_assessor.py`) and registered them in the router, supporting creation, listing, retrieval, and deletion of links between assessors and exam slots. [[1]](diffhunk://#diff-eb63ddc4b7cdfbef7c41b0e50d02042782d2d4b6c4b0d46ae9f7d8fb138691a2R1-R79) [[2]](diffhunk://#diff-aad1c0644eeb8339dec620e4cd4092b2df156e37d4342eb98a17ff2169204c36R4) [[3]](diffhunk://#diff-aad1c0644eeb8339dec620e4cd4092b2df156e37d4342eb98a17ff2169204c36R17)
- Removed direct handling of assessors and students from exam planning create/update endpoints, delegating this to the new dedicated endpoints for better separation of concerns. [[1]](diffhunk://#diff-a0b4f102013ae7da9e2cbe0ccf60869f7ed54e65e11113fbe00cf0364986f65dL36-L58) [[2]](diffhunk://#diff-a0b4f102013ae7da9e2cbe0ccf60869f7ed54e65e11113fbe00cf0364986f65dL75-L109)
- Updated schemas to reflect the new API design, removing `assessors` and `students` from exam planning schemas and adjusting assessor/student schemas as needed. [[1]](diffhunk://#diff-7d4ee0efcedd4271d323e6e564215dd61402561886c2c605468ab8faef74956aL20-L21) [[2]](diffhunk://#diff-7d4ee0efcedd4271d323e6e564215dd61402561886c2c605468ab8faef74956aL30-L31) [[3]](diffhunk://#diff-6bcd41997a4c1fe0b7735751b53ddcce8624b3ce5f63bac6175afdeda4fc5971R52) [[4]](diffhunk://#diff-6bcd41997a4c1fe0b7735751b53ddcce8624b3ce5f63bac6175afdeda4fc5971R61) [[5]](diffhunk://#diff-0c2ff2a4159edf450557d14ee1e50cbe0c727988a11f420e17252103e3e80660L12-R17)

**Frontend: Service and UI updates**
- Introduced new frontend service modules for exam assessors and students, providing functions to list, create, update, and delete links. [[1]](diffhunk://#diff-5a8bc40a1e7eec598310118cfb1b7e0c7e1b0b1343fdd228ffe93c12fdc6b305R1-R13) [[2]](diffhunk://#diff-c98828cbae63bf84337a35744a10b7d0f2851f9b126a546fceadfb4bffbc1581R1-R20)
- Refactored the exam detail view to use these new APIs, allowing real-time linking/unlinking of assessors and students, and updating UI logic to match the new backend structure. [[1]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaR7-R9) [[2]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL67-R73) [[3]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL85-R105) [[4]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL136-L144) [[5]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL162-L169) [[6]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL227-R318) [[7]](diffhunk://#diff-5ca8efd16ea4064c3db69fa168129ce4efb3140982f4edba1b54463c600c97eaL238-R328)