### PR TITLE
Refactor exam-planning structure and add exam-assessor endpoint

### DIFF
--- a/Source/backend/app/api/router.py
+++ b/Source/backend/app/api/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 
 from app.api.routes.exam_planning import router as exam_planning_router
+from app.api.routes.exam_assessor import router as exam_assessor_router
 from app.api.routes.assessor import router as assessor_router
 from app.api.routes.auth import router as auth_router
 from app.api.routes.student import router as student_router
@@ -13,6 +14,7 @@ api_router = APIRouter()
 api_router.include_router(health_router)
 api_router.include_router(auth_router, prefix=settings.api_prefix)
 api_router.include_router(exam_student_router, prefix=settings.api_prefix, dependencies=[Depends(get_current_user)])
+api_router.include_router(exam_assessor_router, prefix=settings.api_prefix, dependencies=[Depends(get_current_user)])
 api_router.include_router(exam_planning_router, prefix=settings.api_prefix, dependencies=[Depends(get_current_user)])
 api_router.include_router(assessor_router, prefix=settings.api_prefix, dependencies=[Depends(get_current_user)])
 api_router.include_router(student_router, prefix=settings.api_prefix, dependencies=[Depends(get_current_user)])

--- a/Source/backend/app/api/routes/exam_assessor.py
+++ b/Source/backend/app/api/routes/exam_assessor.py
@@ -1,0 +1,79 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.models.assessor import ExamAssessor
+from app.schemas.assessor import ExamAssessorCreate, ExamAssessorRead
+
+router = APIRouter(prefix="/exam-assessors", tags=["exam-assessors"])
+
+
+@router.post("", response_model=ExamAssessorRead, status_code=status.HTTP_201_CREATED)
+def create_exam_assessor(payload: ExamAssessorCreate, db: Session = Depends(get_db)) -> ExamAssessor:
+    if payload.exam_planning_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="exam_planning_id is required",
+        )
+
+    exam_assessor = ExamAssessor(
+        exam_planning_id=payload.exam_planning_id,
+        assessor_id=payload.assessor_id,
+        assessor_order=payload.assessor_order,
+    )
+
+    db.add(exam_assessor)
+
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Assessor is already linked to this exam slot",
+        ) from exc
+
+    db.refresh(exam_assessor)
+    return exam_assessor
+
+
+@router.get("", response_model=list[ExamAssessorRead])
+def list_exam_assessors(
+    exam_planning_id: Optional[int] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    db: Session = Depends(get_db),
+) -> list[ExamAssessor]:
+    query = select(ExamAssessor)
+
+    if exam_planning_id is not None:
+        query = query.where(ExamAssessor.exam_planning_id == exam_planning_id)
+
+    query = query.order_by(ExamAssessor.assessor_order.asc()).limit(limit).offset(offset)
+    items = db.execute(query).scalars().all()
+    return list(items)
+
+
+@router.get("/{exam_assessor_id}", response_model=ExamAssessorRead)
+def get_exam_assessor(exam_assessor_id: int, db: Session = Depends(get_db)) -> ExamAssessor:
+    exam_assessor = db.get(ExamAssessor, exam_assessor_id)
+
+    if exam_assessor is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Exam-assessor link not found")
+
+    return exam_assessor
+
+
+@router.delete("/{exam_assessor_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_exam_assessor(exam_assessor_id: int, db: Session = Depends(get_db)) -> None:
+    exam_assessor = db.get(ExamAssessor, exam_assessor_id)
+
+    if exam_assessor is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Exam-assessor link not found")
+
+    db.delete(exam_assessor)
+    db.commit()

--- a/Source/backend/app/api/routes/exam_planning.py
+++ b/Source/backend/app/api/routes/exam_planning.py
@@ -6,8 +6,8 @@ from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.models.exam_planning import Base, ExamPlanning
-from app.models.assessor import ExamAssessor
-from app.models.exam_student import ExamStudent
+
+
 from app.schemas.exam_planning import ExamPlanningCreate, ExamPlanningRead, ExamPlanningUpdate
 
 
@@ -33,29 +33,6 @@ def create_exam_planning(payload: ExamPlanningCreate, db: Session = Depends(get_
     )
 
     db.add(item)
-    db.flush()  # Flush to get the ID without committing
-
-    # Add assessors if provided
-    if payload.assessors:
-        for assessor_data in payload.assessors:
-            exam_assessor = ExamAssessor(
-                exam_planning_id=item.id,
-                assessor_id=assessor_data.assessor_id,
-                assessor_order=assessor_data.assessor_order,
-            )
-            db.add(exam_assessor)
-
-    # Add students if provided
-    if payload.students:
-        for student_data in payload.students:
-            exam_student = ExamStudent(
-                exam_planning_id=item.id,
-                student_id=student_data.student_id,
-                phase=student_data.phase,
-                result=student_data.result,
-            )
-            db.add(exam_student)
-
     db.commit()
     db.refresh(item)
     return item
@@ -72,40 +49,10 @@ def update_exam_planning(
     if item is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Exam planning not found")
 
-    # Update basic fields
-    updates = payload.model_dump(exclude_unset=True, exclude={"assessors", "students"})
+    updates = payload.model_dump(exclude_unset=True)
 
     for field, value in updates.items():
         setattr(item, field, value)
-
-    # Handle assessors update if provided
-    if payload.assessors is not None:
-        # Delete existing assessors
-        db.query(ExamAssessor).filter(ExamAssessor.exam_planning_id == exam_id).delete()
-
-        # Add new assessors
-        for assessor_data in payload.assessors:
-            exam_assessor = ExamAssessor(
-                exam_planning_id=exam_id,
-                assessor_id=assessor_data.assessor_id,
-                assessor_order=assessor_data.assessor_order,
-            )
-            db.add(exam_assessor)
-
-    # Handle students update if provided
-    if payload.students is not None:
-        # Delete existing students
-        db.query(ExamStudent).filter(ExamStudent.exam_planning_id == exam_id).delete()
-
-        # Add new students
-        for student_data in payload.students:
-            exam_student = ExamStudent(
-                exam_planning_id=exam_id,
-                student_id=student_data.student_id,
-                phase=student_data.phase,
-                result=student_data.result,
-            )
-            db.add(exam_student)
 
     db.commit()
     db.refresh(item)

--- a/Source/backend/app/schemas/assessor.py
+++ b/Source/backend/app/schemas/assessor.py
@@ -49,6 +49,7 @@ class AssessorRead(BaseModel):
 
 
 class ExamAssessorCreate(BaseModel):
+    exam_planning_id: Optional[int] = None
     assessor_id: int
     assessor_order: int = Field(ge=1, le=2)
 
@@ -57,6 +58,7 @@ class ExamAssessorRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
+    exam_planning_id: int
     assessor_id: int
     assessor_order: int
     assessor: AssessorRead

--- a/Source/backend/app/schemas/exam_planning.py
+++ b/Source/backend/app/schemas/exam_planning.py
@@ -3,8 +3,8 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.schemas.assessor import ExamAssessorRead, ExamAssessorCreate
-from app.schemas.exam_student import ExamStudentCreate, ExamStudentRead
+from app.schemas.assessor import ExamAssessorRead
+from app.schemas.exam_student import ExamStudentRead
 
 
 PlanningStatus = Literal["planned", "confirmed", "completed", "cancelled"]
@@ -17,8 +17,6 @@ class ExamPlanningCreate(BaseModel):
     room: str = Field(min_length=1, max_length=100)
     exam_time: time
     status: PlanningStatus = "planned"
-    assessors: Optional[list[ExamAssessorCreate]] = Field(default=None)
-    students: Optional[list[ExamStudentCreate]] = Field(default=None)
 
 
 class ExamPlanningUpdate(BaseModel):
@@ -27,8 +25,6 @@ class ExamPlanningUpdate(BaseModel):
     room: Optional[str] = Field(default=None, min_length=1, max_length=100)
     exam_time: Optional[time] = None
     status: Optional[PlanningStatus] = None
-    assessors: Optional[list[ExamAssessorCreate]] = None
-    students: Optional[list[ExamStudentCreate]] = None
 
 
 class ExamPlanningRead(BaseModel):

--- a/Source/backend/app/schemas/exam_student.py
+++ b/Source/backend/app/schemas/exam_student.py
@@ -9,12 +9,12 @@ from app.schemas.student import StudentRead
 class ExamStudentCreate(BaseModel):
     exam_planning_id: int
     student_id: int
-    phase: str = Field(min_length=1, max_length=100)
+    phase: str = Field(default="", max_length=100)
     result: Optional[str] = Field(default=None, max_length=50)
 
 
 class ExamStudentUpdate(BaseModel):
-    phase: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    phase: Optional[str] = Field(default=None, max_length=100)
     result: Optional[str] = Field(default=None, max_length=50)
 
 


### PR DESCRIPTION
This pull request refactors how exam assessors and students are managed in exam planning. The main change is to decouple the creation and management of exam assessors and students from the exam planning endpoints, moving their handling to dedicated routes and schemas. This results in a cleaner API design and better separation of concerns.

Key changes:

**API Refactoring and Routing:**
- Added a new `exam_assessor` API route with endpoints to create, list, retrieve, and delete exam-assessor links, including proper error handling for duplicates and missing references. (`Source/backend/app/api/routes/exam_assessor.py`, `Source/backend/app/api/router.py`) [[1]](diffhunk://#diff-eb63ddc4b7cdfbef7c41b0e50d02042782d2d4b6c4b0d46ae9f7d8fb138691a2R1-R79) [[2]](diffhunk://#diff-aad1c0644eeb8339dec620e4cd4092b2df156e37d4342eb98a17ff2169204c36R4) [[3]](diffhunk://#diff-aad1c0644eeb8339dec620e4cd4092b2df156e37d4342eb98a17ff2169204c36R17)

**Exam Planning Endpoint Simplification:**
- Removed logic from `exam_planning` endpoints that previously created, updated, or deleted exam assessors and students as part of exam planning creation or update. Now, exam planning endpoints only handle exam planning data. (`Source/backend/app/api/routes/exam_planning.py`) [[1]](diffhunk://#diff-a0b4f102013ae7da9e2cbe0ccf60869f7ed54e65e11113fbe00cf0364986f65dL36-L58) [[2]](diffhunk://#diff-a0b4f102013ae7da9e2cbe0ccf60869f7ed54e65e11113fbe00cf0364986f65dL75-L109)

**Schema Updates:**
- Updated `ExamPlanningCreate` and `ExamPlanningUpdate` schemas to remove `assessors` and `students` fields, reflecting the new approach where these are managed separately. (`Source/backend/app/schemas/exam_planning.py`) [[1]](diffhunk://#diff-7d4ee0efcedd4271d323e6e564215dd61402561886c2c605468ab8faef74956aL20-L21) [[2]](diffhunk://#diff-7d4ee0efcedd4271d323e6e564215dd61402561886c2c605468ab8faef74956aL30-L31)
- Updated `ExamAssessorCreate` and `ExamAssessorRead` schemas to include `exam_planning_id` as a field, supporting the new dedicated endpoints. (`Source/backend/app/schemas/assessor.py`) [[1]](diffhunk://#diff-6bcd41997a4c1fe0b7735751b53ddcce8624b3ce5f63bac6175afdeda4fc5971R52) [[2]](diffhunk://#diff-6bcd41997a4c1fe0b7735751b53ddcce8624b3ce5f63bac6175afdeda4fc5971R61)

**Minor Validation Tweaks:**
- Adjusted validation for the `phase` field in `ExamStudentCreate` and `ExamStudentUpdate` to allow empty strings and removed the minimum length requirement. (`Source/backend/app/schemas/exam_student.py`)